### PR TITLE
iOS: Added Complying with Encryption Export Regulations to info.plist

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,11 +30,6 @@
 	<string>TempBox needs access to photo library to import addresses</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
-	<!-- <key>UIBackgroundModes</key>
-	<array>
-		<string>fetch</string>
-		<string>remote-notification</string>
-	</array> -->
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -54,5 +49,7 @@
 	</array>
 	<key>UISupportsDocumentBrowser</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
On iOS added Complying with Encryption Export Regulations key to info.plist based in documentation at [developer.apple.com](https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations)
